### PR TITLE
EPMTIOOPS-20486 | Add Access Claims API documentation

### DIFF
--- a/src/data/navigation.js
+++ b/src/data/navigation.js
@@ -15,6 +15,7 @@ const navigation = [
       { title: "Bugs", href: "/docs/api/bugs" },
       { title: "Custom Bug Export Connections", href: "/docs/api/connections" },
       { title: "Bug Report Confirmations", href: "/docs/api/bug-report-confirmations" },
+      { title: "Access Claims", href: "/docs/api/access-claims" },
       { title: "Test Cases", href: "/docs/api/test-cases" },
       { title: "Test Case Tests", href: "/docs/api/test-case-tests" },
     ],

--- a/src/pages/docs/api/access-claims.md
+++ b/src/pages/docs/api/access-claims.md
@@ -1,0 +1,78 @@
+---
+title: Access Claims
+description: Create and manage access claims groups and test accounts
+---
+
+Create access claims groups pre-populated with test accounts and an expiration, so testers can access password-protected pages during a test cycle. This mirrors what you can already do manually in the Access Claims UI.
+
+## List access claims
+
+Returns the customer's access claims pages.
+
+**Endpoint:** `GET /access_claims`
+
+**Response:** `200 OK`
+
+Returns `access_claim_pages`, an array of access claims pages (`id`, `page_url`, `name`, `intro`), plus `meta.base_path` — the Access Claims base URL used to build full page links.
+
+**Error Responses:**
+
+- `401 Unauthorized` - Missing or invalid API token
+- `403 Forbidden` - Access Claims is not enabled for your account
+
+## Create an access claims group
+
+Create a new access claims group with initial test accounts and an expiration, in one call.
+
+**Endpoint:** `POST /access_claims`
+
+**Request Body:**
+
+- `name` (string, required) - Group name
+- `intro` (string, optional) - Introductory text shown on the access claims page
+- `test_cycle_url` (string, optional) - URL of the related test cycle
+- `expiration_period` (number, required) - Days until the group expires. One of `1`, `2`, `7`, `14`, `30`, `90`, `180`, `365`
+- `access_entries` (array[Access Entry Create], required, min 1) - Test accounts to create in this group
+  - `credentials` (string, required) - Login credentials for this test account (format is up to you — e.g. `"username:password"` — testers see this text as-is)
+
+**Example Request:**
+
+{% code language="bash" showLineNumbers=true %}
+
+```bash
+curl -X POST "https://api.test.io/customer/v2/access_claims" \
+  -H "Authorization: Token YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "CI Run #4821",
+    "expiration_period": 2,
+    "access_entries": [
+      { "credentials": "user1:pass1" },
+      { "credentials": "user2:pass2" }
+    ]
+  }'
+```
+
+{% /code %}
+
+**Response:** `201 Created`
+
+```json
+{
+  "id": 42,
+  "token": "abc123",
+  "page_url": "https://access.claims/pages/abc123",
+  "name": "CI Run #4821",
+  "expires_at": "2026-08-12T10:00:00Z",
+  "access_entries": [{ "id": 101 }, { "id": 102 }]
+}
+```
+
+Credentials are never returned in the response — store what you sent, since it isn't retrievable afterward.
+
+**Error Responses:**
+
+- `400 Bad Request` - Missing required field, or `expiration_period`/`access_entries` value fails validation
+- `401 Unauthorized` - Missing or invalid API token
+- `403 Forbidden` - Access Claims is not enabled for your account
+- `422 Unprocessable Entity` - The access claims group could not be created

--- a/src/pages/docs/api/overview.md
+++ b/src/pages/docs/api/overview.md
@@ -44,6 +44,7 @@ The API provides access to the following resources:
 - **[Test Environments](/docs/api/test-environments)** - Manage test environments
 - **[Test Templates](/docs/api/test-templates)** - List test templates
 - **[Bug Report Confirmations](/docs/api/bug-report-confirmations)** - Create bug report confirmations
+- **[Access Claims](/docs/api/access-claims)** - Create and manage access claims groups and test accounts
 
 ## Response Format
 


### PR DESCRIPTION
https://jiraeu.epam.com/browse/EPMTIOOPS-20486

Documents the Access Claims Customer API v2 resource: the existing `GET /access_claims` (previously undocumented) and the new `POST /access_claims` (test-IO/app#TODO), which lets customers create an access claims group with initial test accounts and an expiration via the API.

app PR - https://github.com/test-IO/app/pull/12432
access claims PR - https://github.com/test-IO/access-claims/pull/381

<img width="962" height="853" alt="image" src="https://github.com/user-attachments/assets/d13e7ec2-43d3-41f7-9667-63f36fa60ae0" />