### PR TITLE
[EPMTIOOPS-20537] Document Test Cases list, update, and delete endpoints

### DIFF
--- a/src/pages/docs/api/test-cases.md
+++ b/src/pages/docs/api/test-cases.md
@@ -1,9 +1,60 @@
 ---
 title: Test Cases
-description: Create test cases
+description: Create, list, update, and delete test cases
 ---
 
-Create test cases for your products.
+Create and manage test cases for your products.
+
+## Get test case
+
+Retrieve a specific test case by ID.
+
+**Endpoint:** `GET /products/{product_id}/test_cases/{test_case_id}`
+
+**Parameters:**
+
+- `product_id` (number, required) - ID of the Product
+- `test_case_id` (number, required) - ID of the Test Case
+
+**Example Request:**
+
+{% code language="bash" showLineNumbers=true %}
+
+```bash
+curl -X GET "https://api.test.io/customer/v2/products/1/test_cases/123" \
+  -H "Authorization: Token YOUR_API_TOKEN"
+```
+
+{% /code %}
+
+**Response:** `200 OK`
+
+Returns the test case object. See the response shape in [Create a bulk of test cases](#create-a-bulk-of-test-cases) below.
+
+## List test cases
+
+Returns all visible (non-hidden) test cases for a product.
+
+**Endpoint:** `GET /products/{product_id}/test_cases`
+
+**Parameters:**
+
+- `product_id` (number, required) - ID of the Product
+
+**Example Request:**
+
+{% code language="bash" showLineNumbers=true %}
+
+```bash
+curl -X GET "https://api.test.io/customer/v2/products/1/test_cases" \
+  -H "Authorization: Token YOUR_API_TOKEN"
+```
+
+{% /code %}
+
+**Response:** `200 OK`
+
+Returns an array of test case objects. See the response shape in [Create a bulk of test cases](#create-a-bulk-of-test-cases) below.
 
 ## Create a bulk of test cases
 
@@ -69,3 +120,72 @@ Returns an array of created test case objects.
 {% callout type="note" %}
 In the response, the steps field is returned as `steps` (not `test_case_steps` as in the request). Each step object in the response also includes `id`, `test_case_id`, and `target_idx` fields.
 {% /callout %}
+
+## Update test case
+
+Updates the top-level fields of a test case. Test case steps are not managed through this endpoint.
+
+**Endpoint:** `PUT /products/{product_id}/test_cases/{test_case_id}`
+
+**Parameters:**
+
+- `product_id` (number, required) - ID of the Product
+- `test_case_id` (number, required) - ID of the Test Case
+
+All attributes must be provided inside the root object `test_case`. All fields are optional — only the fields you provide are updated.
+
+**Request Body:**
+
+- `title` (string, optional) - Title of the test case
+- `requirements` (string, optional) - Requirements of the test case
+- `target_idx` (string, optional) - Reference of the test case in other system
+- `feature_id` (number, optional) - ID of the Feature to move the test case to. Must belong to the same product.
+
+**Example Request:**
+
+{% code language="bash" showLineNumbers=true %}
+
+```bash
+curl -X PUT "https://api.test.io/customer/v2/products/1/test_cases/123" \
+  -H "Authorization: Token YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "test_case": {
+      "title": "Login Test (updated)"
+    }
+  }'
+```
+
+{% /code %}
+
+**Response:** `200 OK`
+
+Returns the updated test case object. See the response shape in [Create a bulk of test cases](#create-a-bulk-of-test-cases) above.
+
+## Delete test case
+
+Deletes the specified test case from the product.
+
+**Endpoint:** `DELETE /products/{product_id}/test_cases/{test_case_id}`
+
+**Parameters:**
+
+- `product_id` (number, required) - ID of the Product
+- `test_case_id` (number, required) - ID of the Test Case
+
+{% callout type="note" %}
+If the test case is already in use by a test cycle, it is not permanently deleted — it is hidden instead so historical test results remain intact. Hidden test cases no longer appear in [List test cases](#list-test-cases).
+{% /callout %}
+
+**Example Request:**
+
+{% code language="bash" showLineNumbers=true %}
+
+```bash
+curl -X DELETE "https://api.test.io/customer/v2/products/1/test_cases/123" \
+  -H "Authorization: Token YOUR_API_TOKEN"
+```
+
+{% /code %}
+
+**Response:** `204 No Content`

--- a/src/pages/docs/api/test-cases.md
+++ b/src/pages/docs/api/test-cases.md
@@ -144,7 +144,6 @@ All attributes must be provided inside the root object `test_case`. All fields a
 
 - `id` (number, optional) - ID of an existing step to update or remove. Omit to add a new step.
 - `description` (string, optional) - Description of the step
-- `target_idx` (string, optional) - Reference of the test case step in other system
 - `_destroy` (boolean, optional) - Set to `true` to remove the step identified by `id`
 
 **Example Request:**

--- a/src/pages/docs/api/test-cases.md
+++ b/src/pages/docs/api/test-cases.md
@@ -123,7 +123,7 @@ In the response, the steps field is returned as `steps` (not `test_case_steps` a
 
 ## Update test case
 
-Updates the top-level fields of a test case. Test case steps are not managed through this endpoint.
+Updates the top-level fields of a test case, and optionally its test case steps.
 
 **Endpoint:** `PUT /products/{product_id}/test_cases/{test_case_id}`
 
@@ -132,14 +132,21 @@ Updates the top-level fields of a test case. Test case steps are not managed thr
 - `product_id` (number, required) - ID of the Product
 - `test_case_id` (number, required) - ID of the Test Case
 
-All attributes must be provided inside the root object `test_case`. All fields are optional — only the fields you provide are updated.
+All attributes must be provided inside the root object `test_case`. All fields are optional — only the fields you provide are updated. `feature_id` is not accepted by this endpoint.
 
 **Request Body:**
 
 - `title` (string, optional) - Title of the test case
 - `requirements` (string, optional) - Requirements of the test case
 - `target_idx` (string, optional) - Reference of the test case in other system
-- `feature_id` (number, optional) - ID of the Feature to move the test case to. Must belong to the same product.
+- `test_case_steps` (array[Step], optional) - Array of step objects to create, update, or remove
+
+**Step Object:**
+
+- `id` (number, optional) - ID of an existing step to update or remove. Omit to add a new step.
+- `description` (string, optional) - Description of the step
+- `target_idx` (string, optional) - Reference of the test case step in other system
+- `_destroy` (boolean, optional) - Set to `true` to remove the step identified by `id`
 
 **Example Request:**
 
@@ -151,7 +158,12 @@ curl -X PUT "https://api.test.io/customer/v2/products/1/test_cases/123" \
   -H "Content-Type: application/json" \
   -d '{
     "test_case": {
-      "title": "Login Test (updated)"
+      "title": "Login Test (updated)",
+      "test_case_steps": [
+        { "id": 456, "description": "Navigate to login page (updated)" },
+        { "description": "Confirm dashboard is shown" },
+        { "id": 789, "_destroy": true }
+      ]
     }
   }'
 ```
@@ -161,6 +173,10 @@ curl -X PUT "https://api.test.io/customer/v2/products/1/test_cases/123" \
 **Response:** `200 OK`
 
 Returns the updated test case object. See the response shape in [Create a bulk of test cases](#create-a-bulk-of-test-cases) above.
+
+{% callout type="note" %}
+If the test case is already in use by a test cycle, its steps are not edited in place — a hidden shadow copy of the test case is created (or reused) and the step changes are applied there instead, so historical test results tied to the original steps remain intact. In that case the response is the shadow copy: it has a different `id` from the one in the request URL, and subsequent requests should use that new `id`. The original `test_case_id` will then return `404` from [Get test case](#get-test-case), same as a deleted-but-in-use test case.
+{% /callout %}
 
 ## Delete test case
 

--- a/src/pages/docs/api/test-cases.md
+++ b/src/pages/docs/api/test-cases.md
@@ -132,7 +132,7 @@ Updates the top-level fields of a test case, and optionally its test case steps.
 - `product_id` (number, required) - ID of the Product
 - `test_case_id` (number, required) - ID of the Test Case
 
-All attributes must be provided inside the root object `test_case`. All fields are optional — only the fields you provide are updated. `feature_id` and `target_idx` are not accepted by this endpoint.
+All attributes must be provided inside the root object `test_case`. All fields are optional — only the fields you provide are updated. `feature_id` is not accepted by this endpoint, and top-level `target_idx` cannot be changed once the test case is created.
 
 **Request Body:**
 
@@ -144,6 +144,7 @@ All attributes must be provided inside the root object `test_case`. All fields a
 
 - `id` (number, optional) - ID of an existing step to update or remove. Omit to add a new step.
 - `description` (string, optional) - Description of the step
+- `target_idx` (string, optional) - Reference of the step in another system. Only used when adding a new step (no `id`); ignored when editing an existing step.
 - `_destroy` (boolean, optional) - Set to `true` to remove the step identified by `id`
 
 **Example Request:**
@@ -159,7 +160,7 @@ curl -X PUT "https://api.test.io/customer/v2/products/1/test_cases/123" \
       "title": "Login Test (updated)",
       "test_case_steps": [
         { "id": 456, "description": "Navigate to login page (updated)" },
-        { "description": "Confirm dashboard is shown" },
+        { "description": "Confirm dashboard is shown", "target_idx": "ext-789" },
         { "id": 789, "_destroy": true }
       ]
     }

--- a/src/pages/docs/api/test-cases.md
+++ b/src/pages/docs/api/test-cases.md
@@ -175,7 +175,7 @@ curl -X PUT "https://api.test.io/customer/v2/products/1/test_cases/123" \
 Returns the updated test case object. See the response shape in [Create a bulk of test cases](#create-a-bulk-of-test-cases) above.
 
 {% callout type="note" %}
-If the test case is already in use by a test cycle, its steps are not edited in place — a hidden shadow copy of the test case is created (or reused) and the step changes are applied there instead, so historical test results tied to the original steps remain intact. In that case the response is the shadow copy: it has a different `id` from the one in the request URL, and subsequent requests should use that new `id`. The original `test_case_id` will then return `404` from [Get test case](#get-test-case), same as a deleted-but-in-use test case.
+If the test case is already in use by a test cycle, its steps are not edited in place — a hidden shadow copy of the test case is created (or reused) and the step changes are applied there instead, so historical test results tied to the original steps remain intact. In that case the response is the shadow copy: it has a different `id` from the one in the request URL, and subsequent requests should use that new `id`. The original `test_case_id` will then return `404` from [Get test case](#get-test-case).
 {% /callout %}
 
 ## Delete test case
@@ -190,7 +190,7 @@ Deletes the specified test case from the product.
 - `test_case_id` (number, required) - ID of the Test Case
 
 {% callout type="note" %}
-If the test case is already in use by a test cycle, it is not permanently deleted — it is hidden instead so historical test results remain intact. Hidden test cases no longer appear in [List test cases](#list-test-cases).
+If the test case is already in use by a test cycle, it is not permanently deleted — it is hidden instead so historical test results remain intact. Hidden test cases no longer appear in [List test cases](#list-test-cases), and subsequent `GET` requests for that `test_case_id` return `404`.
 {% /callout %}
 
 **Example Request:**

--- a/src/pages/docs/api/test-cases.md
+++ b/src/pages/docs/api/test-cases.md
@@ -132,13 +132,12 @@ Updates the top-level fields of a test case, and optionally its test case steps.
 - `product_id` (number, required) - ID of the Product
 - `test_case_id` (number, required) - ID of the Test Case
 
-All attributes must be provided inside the root object `test_case`. All fields are optional — only the fields you provide are updated. `feature_id` is not accepted by this endpoint.
+All attributes must be provided inside the root object `test_case`. All fields are optional — only the fields you provide are updated. `feature_id` and `target_idx` are not accepted by this endpoint.
 
 **Request Body:**
 
 - `title` (string, optional) - Title of the test case
 - `requirements` (string, optional) - Requirements of the test case
-- `target_idx` (string, optional) - Reference of the test case in other system
 - `test_case_steps` (array[Step], optional) - Array of step objects to create, update, or remove
 
 **Step Object:**


### PR DESCRIPTION
## [EPMTIOOPS-20537](https://jiraeu.epam.com/browse/EPMTIOOPS-20537)
[S][Customer][API] Extend API capabilities for Test Cases
---

## Problem

The Test Cases API doc (`src/pages/docs/api/test-cases.md`) only covered bulk create. It was missing the get-by-id endpoint (already existed in the API but was undocumented) and the new list/update/delete endpoints added in test-IO/app#12435 for EPMTIOOPS-20537.

## Solution

Added sections, following the existing doc conventions (see `user-stories.md`):

- **Get test case** — `GET /products/{product_id}/test_cases/{test_case_id}` (pre-existing endpoint, was undocumented)
- **List test cases** — `GET /products/{product_id}/test_cases` (new)
- **Update test case** — `PUT /products/{product_id}/test_cases/{test_case_id}` (new)
- **Delete test case** — `DELETE /products/{product_id}/test_cases/{test_case_id}` (new), with a callout explaining the hide-instead-of-delete behavior when a test case is already in use by a test cycle

## Test plan

- [x] src/pages/docs/api/test-cases.md renders correctly with `npm run dev`.

1. Get test case
<img width="1512" height="982" alt="Screenshot 2026-08-19 at 17 31 00" src="https://github.com/user-attachments/assets/0354e036-478b-40f5-ba78-5a677c99bfb1" />

2. List test cases
<img width="1512" height="982" alt="Screenshot 2026-08-19 at 17 31 13" src="https://github.com/user-attachments/assets/3067b776-f0ac-483b-85fc-0befd373c73e" />

3. Update test case 
<img width="1512" height="982" alt="Screenshot 2026-08-20 at 08 00 03" src="https://github.com/user-attachments/assets/aafed2f0-b1ce-46c9-8e4a-4cfe8af1f28e" />

4. Delete test case
<img width="1512" height="982" alt="Screenshot 2026-08-19 at 17 44 44" src="https://github.com/user-attachments/assets/21de64bc-2a52-48b7-9a60-907da9bcabe3" />
