### PR TITLE
[EPMTIOOPS-20538] Document Feature update and delete endpoints

### DIFF
--- a/src/pages/docs/api/features.md
+++ b/src/pages/docs/api/features.md
@@ -250,8 +250,6 @@ All attributes must be provided inside the root object `feature`.
   - `title` (string, optional) - Feature title
   - `description` (string, optional) - Feature description
   - `howtofind` (string, optional) - Instructions on how to find the feature
-  - `target_idx` (string, optional) - Target index
-  - `use_markdown` (boolean, optional) - Whether to use markdown formatting
 
 **Query Parameters:**
 

--- a/src/pages/docs/api/features.md
+++ b/src/pages/docs/api/features.md
@@ -1,6 +1,6 @@
 ---
 title: Features
-description: List, create, and copy features
+description: List, create, update, delete, and copy features
 ---
 
 Manage features for your products.
@@ -230,6 +230,82 @@ curl -X POST "https://api.test.io/customer/v2/features" \
 ```
 
 {% /code %}
+
+## Update feature
+
+Updates the top-level fields of a feature. All fields are optional — only the fields you provide are updated.
+
+**Endpoint:** `PUT /features/{feature_id}`
+
+**Parameters:**
+
+- `feature_id` (number, required) - ID of the Feature
+
+All attributes must be provided inside the root object `feature`.
+
+**Request Body:**
+
+- `section_ids` (array[number], optional) - Array of section IDs to assign the feature to, replacing its current sections
+- `feature` (object, optional) - Feature object
+  - `title` (string, optional) - Feature title
+  - `description` (string, optional) - Feature description
+  - `howtofind` (string, optional) - Instructions on how to find the feature
+  - `target_idx` (string, optional) - Target index
+  - `use_markdown` (boolean, optional) - Whether to use markdown formatting
+
+**Query Parameters:**
+
+| Parameter    | Type  | Required | Description                                                                                                        |
+| ------------ | ----- | -------- | ------------------------------------------------------------------------------------------------------------------ |
+| `includes[]` | array | No       | Optional associations to expand. Supported value: `user_stories`. See [List features](#list-features) for details. |
+
+**Example Request:**
+
+{% code language="bash" showLineNumbers=true %}
+
+```bash
+curl -X PUT "https://api.test.io/customer/v2/features/15" \
+  -H "Authorization: Token YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "feature": {
+      "title": "Account Management (updated)"
+    }
+  }'
+```
+
+{% /code %}
+
+**Response:** `200 OK`
+
+Returns the updated feature object. See the response shape in [Create feature](#create-feature) above.
+
+## Delete feature
+
+Deletes the specified feature.
+
+**Endpoint:** `DELETE /features/{feature_id}`
+
+**Parameters:**
+
+- `feature_id` (number, required) - ID of the Feature
+
+{% callout type="note" %}
+If the feature is already in use by a test cycle, it is not permanently deleted — it is hidden instead so historical test results remain intact. Hidden features no longer appear in [List features](#list-features).
+{% /callout %}
+
+**Example Request:**
+
+{% code language="bash" showLineNumbers=true %}
+
+```bash
+curl -X DELETE "https://api.test.io/customer/v2/features/15" \
+  -H "Authorization: Token YOUR_API_TOKEN"
+```
+
+{% /code %}
+
+**Response:** `204 No Content`
 
 ## Copy features
 

--- a/src/pages/docs/api/features.md
+++ b/src/pages/docs/api/features.md
@@ -250,6 +250,10 @@ All attributes must be provided inside the root object `feature`.
   - `title` (string, optional) - Feature title
   - `description` (string, optional) - Feature description
   - `howtofind` (string, optional) - Instructions on how to find the feature
+  - `user_stories` (array[object], optional) - User stories to add, update, or remove
+    - `id` (number, optional) - ID of an existing user story to update or remove. Omit to create a new user story.
+    - `path` (string, optional) - User story description
+    - `_destroy` (boolean, optional) - Set to `true` along with `id` to remove the user story
 
 **Query Parameters:**
 
@@ -277,6 +281,29 @@ curl -X PUT "https://api.test.io/customer/v2/features/15" \
 **Response:** `200 OK`
 
 Returns the updated feature object. See the response shape in [Create feature](#create-feature) above.
+
+**Example Request (managing user stories):**
+
+{% code language="bash" showLineNumbers=true %}
+
+```bash
+curl -X PUT "https://api.test.io/customer/v2/features/15" \
+  -H "Authorization: Token YOUR_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "feature": {
+      "user_stories": [
+        { "path": "As a user I can reset my password" },
+        { "id": 10, "path": "As a user I can log in (updated)" },
+        { "id": 11, "_destroy": true }
+      ]
+    }
+  }'
+```
+
+{% /code %}
+
+**Response:** `200 OK`
 
 ## Delete feature
 

--- a/src/pages/docs/api/features.md
+++ b/src/pages/docs/api/features.md
@@ -255,11 +255,7 @@ All attributes must be provided inside the root object `feature`.
     - `path` (string, optional) - User story description
     - `_destroy` (boolean, optional) - Set to `true` along with `id` to remove the user story
 
-**Query Parameters:**
-
-| Parameter    | Type  | Required | Description                                                                                                        |
-| ------------ | ----- | -------- | ------------------------------------------------------------------------------------------------------------------ |
-| `includes[]` | array | No       | Optional associations to expand. Supported value: `user_stories`. See [List features](#list-features) for details. |
+> `user_stories` in the response is always returned as expanded objects (`id`, `path`, `title`, `feature_id`) — there is no `includes[]=user_stories` toggle for this endpoint, unlike [List features](#list-features).
 
 **Example Request:**
 


### PR DESCRIPTION
## [EPMTIOOPS-20538](https://jiraeu.epam.com/browse/EPMTIOOPS-20538)
[S][Customer][API] Extend API capabilities for Features
---

## Problem

The Features API guide only documented list, create, and copy — the new `PUT` and `DELETE` endpoints (test-IO/app#12438) were undocumented.

## Solution

Added "Update feature" and "Delete feature" sections to `features.md`, following the same structure as the existing endpoints (and the recent Test Cases API docs).

## Steps to verify

1. `src/pages/docs/api/features.md` renders correctly with `npm run dev`.
2. New sections match the actual API behavior implemented in test-IO/app#12438 (partial update via `feature` object; delete hides the feature if it's used in a test cycle, otherwise destroys it).

## Screenshots

1. Update Feature
<img width="1512" height="982" alt="Screenshot 2026-08-21 at 20 13 10" src="https://github.com/user-attachments/assets/c23b469d-a2ea-4acc-9e64-890bdcd714e5" />

2. Delete Feature
<img width="1512" height="982" alt="Screenshot 2026-08-21 at 20 13 23" src="https://github.com/user-attachments/assets/8f4502da-ebf3-4d61-892e-ca60481c6420" />
