### PR TITLE
[EPMTIOOPS-20532] Document pagination limits on paginated Customer API v2 endpoints

### DIFF
--- a/src/pages/docs/api/bugs.md
+++ b/src/pages/docs/api/bugs.md
@@ -9,23 +9,32 @@ Manage bugs found during testing.
 
 ## Fetch bugs
 
-Retrieve bugs with optional filtering.
+Returns a paginated list of bugs, with optional filtering.
 
-**Endpoint:** `GET /bugs`
+**Endpoint:** `GET /bugs{?page,per_page}`
 
 **Query Parameters:**
 
+- `page` (number, optional) - Page number of the result set. Default: 1
+- `per_page` (number, optional) - Number of bugs per page. Maximum: 500. Default: 25 when `page` is given, 500 otherwise
 - `filter_product_ids` (string, optional) - Comma-separated product IDs
 - `filter_section_ids` (string, optional) - Comma-separated section IDs
 - `filter_test_cycle_ids` (string, optional) - Comma-separated test cycle IDs
 - `export_status` (string, optional) - Export status filter. Values: `export_requested`, `not_exported`, `exported`
+
+Responses are always paginated and never return more than 500 bugs. A `per_page` above 500 is
+reduced to 500 rather than rejected, so read `meta.per_page` from the response — not the value you
+requested — when working out how many pages to fetch. `page` and `per_page` must both be 1 or
+greater; `0` or a negative number returns `400 Bad Request`.
+
+To retrieve every bug, request successive pages until an empty `bugs` array comes back.
 
 **Example Request:**
 
 {% code language="bash" showLineNumbers=true %}
 
 ```bash
-curl -X GET "https://api.test.io/customer/v2/bugs?filter_product_ids=1,2&export_status=not_exported" \
+curl -X GET "https://api.test.io/customer/v2/bugs?filter_product_ids=1,2&export_status=not_exported&page=1&per_page=100" \
   -H "Authorization: Token YOUR_API_TOKEN"
 ```
 
@@ -37,6 +46,11 @@ curl -X GET "https://api.test.io/customer/v2/bugs?filter_product_ids=1,2&export_
 
 ```json
 {
+  "meta": {
+    "record_count": 600,
+    "page": 1,
+    "per_page": 100
+  },
   "bugs": [
     {
       "id": 123,
@@ -55,6 +69,15 @@ curl -X GET "https://api.test.io/customer/v2/bugs?filter_product_ids=1,2&export_
 ```
 
 {% /code %}
+
+**Response Fields:**
+
+| Field               | Type    | Description                                                   |
+| ------------------- | ------- | ------------------------------------------------------------- |
+| `meta.record_count` | integer | Total bugs matching the query, across all pages               |
+| `meta.page`         | integer | Page returned                                                 |
+| `meta.per_page`     | integer | Page size actually applied, after the 500 maximum is enforced |
+| `bugs`              | array   | Bugs on this page                                             |
 
 ## Get bug
 

--- a/src/pages/docs/api/exploratory-tests.md
+++ b/src/pages/docs/api/exploratory-tests.md
@@ -189,8 +189,8 @@ Returns a paginated list of exploratory tests for the specified product.
 **Parameters:**
 
 - `product_id` (number, required) - ID of the Product
-- `page` (number, optional) - Page number of the result set
-- `per_page` (number, optional) - Number of items per page when pagination is applied. Used only if **page** is provided. Default: 25
+- `page` (number, optional) - Page number of the result set. Default: 1
+- `per_page` (number, optional) - Number of items per page. Maximum: 500. Default: 25 when `page` is given, 500 otherwise
 
 **Query Parameters:**
 
@@ -200,7 +200,10 @@ Returns a paginated list of exploratory tests for the specified product.
 
 **Notes:**
 
-If `page` parameter is omitted, pagination is not applied and the last 150 tests are returned.
+Responses are always paginated and never return more than 500 tests. A `per_page` above 500 is
+reduced to 500 rather than rejected, so read `meta.per_page` from the response — not the value you
+requested — when working out how many pages to fetch. `page` and `per_page` must both be 1 or
+greater; `0` or a negative number returns `400 Bad Request`.
 
 **Example Request:**
 
@@ -215,7 +218,28 @@ curl -X GET "https://api.test.io/customer/v2/products/1/exploratory_tests?page=1
 
 **Response:** `200 OK`
 
-Returns an array of exploratory test objects.
+Returns a `meta` object describing the page, and an array of exploratory test objects.
+
+{% code language="json" showLineNumbers=true %}
+
+```json
+{
+  "meta": {
+    "record_count": 6,
+    "page": 1,
+    "per_page": 500
+  },
+  "exploratory_tests": []
+}
+```
+
+{% /code %}
+
+| Field               | Type    | Description                                                   |
+| ------------------- | ------- | ------------------------------------------------------------- |
+| `meta.record_count` | integer | Total tests matching the query, across all pages              |
+| `meta.page`         | integer | Page returned                                                 |
+| `meta.per_page`     | integer | Page size actually applied, after the 500 maximum is enforced |
 
 ## Create exploratory test
 

--- a/src/pages/docs/api/test-cases.md
+++ b/src/pages/docs/api/test-cases.md
@@ -33,20 +33,29 @@ Returns the test case object. See the response shape in [Create a bulk of test c
 
 ## List test cases
 
-Returns all visible (non-hidden) test cases for a product.
+Returns a paginated list of visible (non-hidden) test cases for a product.
 
-**Endpoint:** `GET /products/{product_id}/test_cases`
+**Endpoint:** `GET /products/{product_id}/test_cases{?page,per_page}`
 
 **Parameters:**
 
 - `product_id` (number, required) - ID of the Product
+- `page` (number, optional) - Page number of the result set. Default: 1
+- `per_page` (number, optional) - Number of test cases per page. Maximum: 500. Default: 25 when `page` is given, 500 otherwise
+
+Responses are always paginated and never return more than 500 test cases. A `per_page` above 500
+is reduced to 500 rather than rejected, so read `meta.per_page` from the response — not the value
+you requested — when working out how many pages to fetch. `page` and `per_page` must both be 1 or
+greater; `0` or a negative number returns `400 Bad Request`.
+
+To retrieve every test case, request successive pages until an empty `test_cases` array comes back.
 
 **Example Request:**
 
 {% code language="bash" showLineNumbers=true %}
 
 ```bash
-curl -X GET "https://api.test.io/customer/v2/products/1/test_cases" \
+curl -X GET "https://api.test.io/customer/v2/products/1/test_cases?page=1&per_page=100" \
   -H "Authorization: Token YOUR_API_TOKEN"
 ```
 
@@ -54,7 +63,29 @@ curl -X GET "https://api.test.io/customer/v2/products/1/test_cases" \
 
 **Response:** `200 OK`
 
-Returns an array of test case objects. See the response shape in [Create a bulk of test cases](#create-a-bulk-of-test-cases) below.
+{% code language="json" showLineNumbers=true %}
+
+```json
+{
+  "meta": {
+    "record_count": 600,
+    "page": 1,
+    "per_page": 100
+  },
+  "test_cases": []
+}
+```
+
+{% /code %}
+
+**Response Fields:**
+
+| Field                | Type    | Description                                                        |
+| -------------------- | ------- | -------------------------------------------------------------------- |
+| `meta.record_count`  | integer | Total test cases matching the query, across all pages               |
+| `meta.page`          | integer | Page returned                                                       |
+| `meta.per_page`      | integer | Page size actually applied, after the 500 maximum is enforced       |
+| `test_cases`         | array   | Test cases on this page. See the object shape in [Create a bulk of test cases](#create-a-bulk-of-test-cases) below. |
 
 ## Create a bulk of test cases
 

--- a/src/pages/docs/api/test-cases.md
+++ b/src/pages/docs/api/test-cases.md
@@ -80,12 +80,14 @@ curl -X GET "https://api.test.io/customer/v2/products/1/test_cases?page=1&per_pa
 
 **Response Fields:**
 
-| Field                | Type    | Description                                                        |
-| -------------------- | ------- | -------------------------------------------------------------------- |
-| `meta.record_count`  | integer | Total test cases matching the query, across all pages               |
-| `meta.page`          | integer | Page returned                                                       |
-| `meta.per_page`      | integer | Page size actually applied, after the 500 maximum is enforced       |
-| `test_cases`         | array   | Test cases on this page. See the object shape in [Create a bulk of test cases](#create-a-bulk-of-test-cases) below. |
+| Field               | Type    | Description                                                   |
+| ------------------- | ------- | ------------------------------------------------------------- |
+| `meta.record_count` | integer | Total test cases matching the query, across all pages         |
+| `meta.page`         | integer | Page returned                                                 |
+| `meta.per_page`     | integer | Page size actually applied, after the 500 maximum is enforced |
+| `test_cases`        | array   | Test cases on this page                                       |
+
+See the test case object shape in [Create a bulk of test cases](#create-a-bulk-of-test-cases) below.
 
 ## Create a bulk of test cases
 

--- a/src/pages/docs/api/user-story-version-executions.md
+++ b/src/pages/docs/api/user-story-version-executions.md
@@ -30,7 +30,7 @@ Returns a paginated list of user story version executions for the current custom
 | Parameter                  | Type    | Required | Description                                                                                                                                    |
 | -------------------------- | ------- | -------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | `page`                     | integer | No       | Page number for pagination (default: 1)                                                                                                        |
-| `per_page`                 | integer | No       | Number of records per page (default: 25)                                                                                                       |
+| `per_page`                 | integer | No       | Number of records per page. Maximum: 500 (default: 25 when `page` is given, 500 otherwise)                                                     |
 | `user_story_ids[]`         | array   | No       | Filter by user story IDs. Only executions for these user stories are returned. Pass multiple values as `user_story_ids[]=1&user_story_ids[]=2` |
 | `user_story_version_ids[]` | array   | No       | Filter by user story version IDs. Pass multiple values as `user_story_version_ids[]=10&user_story_version_ids[]=11`                            |
 | `order`                    | string  | No       | Sort order by creation time: `asc` (oldest first) or `desc` (newest first). Default: `asc`                                                     |
@@ -75,6 +75,8 @@ curl -X GET "https://api.test.io/customer/v2/user_story_version_executions?user_
 | Attribute                       | Type    | Description                                                       |
 | ------------------------------- | ------- | ----------------------------------------------------------------- |
 | `meta.record_count`             | integer | Total number of executions matching the query (before pagination) |
+| `meta.page`                     | integer | Page returned                                                     |
+| `meta.per_page`                 | integer | Page size actually applied, after the 500 maximum is enforced     |
 | `user_story_version_executions` | array   | List of execution objects (see below)                             |
 
 **User story version execution object attributes:**
@@ -124,7 +126,9 @@ curl -X GET "https://api.test.io/customer/v2/user_story_version_executions?user_
 ```json
 {
   "meta": {
-    "record_count": 42
+    "record_count": 42,
+    "page": 1,
+    "per_page": 25
   },
   "user_story_version_executions": [
     {
@@ -174,4 +178,5 @@ curl -X GET "https://api.test.io/customer/v2/user_story_version_executions?user_
 - Use `user_story_ids[]` when you want all executions for specific user stories (e.g. for a feature or product view).
 - Use `user_story_version_ids[]` when you need executions for specific user story versions (e.g. tied to a test cycle or version snapshot).
 - Use `order=desc` and `per_page` to fetch the most recent executions first and control page size.
-- `meta.record_count` reflects the total matching the filters; use it with `per_page` to compute total pages or show “X of Y” in the UI.
+- `meta.record_count` reflects the total matching the filters; use it with the `meta.per_page` returned in the response — not the value you requested — to compute total pages or show “X of Y” in the UI. A `per_page` above 500 is reduced to 500 rather than rejected, so deriving the page count from the requested value would stop short of the last page.
+- `page` and `per_page` must both be 1 or greater; `0` or a negative number returns `400 Bad Request`.


### PR DESCRIPTION
Documents the pagination behaviour shipped in the app PR for EPMTIOOPS-20532.

`GET /customer/v2/bugs` previously returned the customer's **entire** bug collection when the caller
omitted `page`, which exhausted the memory of the pods serving it. The endpoints are now always
paginated and capped at 500 records per request. These docs catch up with that, and correct two
statements that were already wrong before the change.

## Changes

### `bugs.md` — pagination was not documented at all

`page` and `per_page` were missing from the Fetch bugs parameters entirely, and the response example
showed no `meta` even though `record_count` has been returned since 2024. This is part of why the
change caught a customer by surprise: they sent `per_page` and had no documented reason to know that
`page` was also required for it to take effect.

Now documents both parameters, the 500 maximum, that an oversized `per_page` is reduced rather than
rejected, the `400` on non-positive values, and adds the `meta` block plus a response-fields table.

### `exploratory-tests.md` — removed an incorrect claim

> ~~If `page` parameter is omitted, pagination is not applied and the last 150 tests are returned.~~

Wrong in both directions. Pagination is now always applied, and even before this change no limit was
applied at all — the code called `limit(Settings.default_per_page)`, and that key lives under `app:`
in `settings.yml`, so it resolved to `nil` and emitted no `LIMIT` clause. The endpoint had been
returning every test cycle for the product since 2020.

Also corrects "Used only if **page** is provided" on `per_page`, and adds the `meta` block — that
endpoint previously returned no `meta` at all.

### `user-story-version-executions.md` — corrected page-count guidance

> ~~use it with `per_page` to compute total pages~~

Following that with `per_page=1000` now computes one page, returns 500 records, and silently misses
the rest. Changed to use the `meta.per_page` **returned in the response** rather than the requested
value, and documents `meta.page` / `meta.per_page`.

## Verified against staging

Values below are from `api.a.testio.space` with 600 bugs seeded for one customer, so the documented
behaviour matches a real response rather than a reading of the code.

| Call | Response |
| --- | --- |
| *(no params)* | 500 rows, `{record_count: 600, page: 1, per_page: 500}` |
| `per_page=3` | 3 rows, `per_page: 3` |
| `per_page=501` | 500 rows, `per_page: 500` |
| `page=2&per_page=500` | 100 rows, `per_page: 500` |
| `page=0` | `400` `page does not have a valid value` |
| `per_page=0` | `400` `per_page does not have a valid value` |
| `/products/3/exploratory_tests` | `{record_count: 6, page: 1, per_page: 500}` |

Paging is lossless across the cap: pages 1 and 2 returned 500 + 100 rows with 0 overlap and 600
distinct ids.

## Not included

**Getting Started is deliberately untouched.** Only 3 of the 24 Customer API v2 list endpoints
paginate — the other 21 return their full collection and take no `page`/`per_page`. A general
"list endpoints are paginated" section would be wrong for most of the API, so that belongs in a
follow-up once the remaining endpoints are migrated.

Prettier clean.
